### PR TITLE
Fix: Add accent color to theme and typings

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -13,11 +13,9 @@ const theme = createTheme({
     secondary: {
       main: '#34A853',
     },
-    // Accent color can be added as a custom field if needed, or mapped to secondary
-    // For now, let's use secondary as the accent color or rely on primary/secondary for accents.
-    // accent: {
-    //   main: '#FBBC05',
-    // },
+    accent: { // Added accent color
+      main: '#FBBC05', // Yellow
+    },
     error: {
       main: '#EA4335',
     },

--- a/frontend/src/react-app-env.d.ts
+++ b/frontend/src/react-app-env.d.ts
@@ -1,1 +1,34 @@
 /// <reference types="react-scripts" />
+
+import '@mui/material/styles';
+
+declare module '@mui/material/styles' {
+  interface Palette {
+    accent: Palette['primary'];
+  }
+  interface PaletteOptions {
+    accent?: PaletteOptions['primary'];
+  }
+}
+
+// This augmentation is also needed for the Button component to accept 'accent' as a color prop.
+// If you plan to use <Button color="accent">, you need this.
+// If you only access accent via theme.palette.accent.main, this might not be strictly necessary
+// but is good for consistency if you might use it on components later.
+declare module '@mui/material/Button' {
+  interface ButtonPropsColorOverrides {
+    accent: true;
+  }
+}
+
+// If you also want to use it on other components that have a `color` prop, like SvgIcon, Chip, etc.
+// declare module '@mui/material/SvgIcon' {
+//   interface SvgIconPropsColorOverrides {
+//     accent: true;
+//   }
+// }
+// declare module '@mui/material/Chip' {
+//   interface ChipPropsColorOverrides {
+//     accent: true;
+//   }
+// }


### PR DESCRIPTION
This commit resolves a compilation error (TS2339) that occurred because the 'accent' color was used in `FolderList.tsx` without being defined in the Material UI theme palette or its corresponding TypeScript typings.

Changes:
- Modified `frontend/src/index.tsx` to include `accent: { main: '#FBBC05' }` in the `theme.palette`.
- Augmented Material UI's `Palette` and `PaletteOptions` interfaces in `frontend/src/react-app-env.d.ts` to make TypeScript aware of the new `accent` palette option.
- Also augmented `ButtonPropsColorOverrides` to allow for `color="accent"` on Buttons.

This ensures that `theme.palette.accent.main` is correctly recognized and available, allowing components to use the accent color as intended by the style guide.